### PR TITLE
WIP: Speed up `PowMap`

### DIFF
--- a/lib/InduceReduce.gi
+++ b/lib/InduceReduce.gi
@@ -174,7 +174,7 @@ InstallValue( IndRed , rec(
         PowMap:= function(GR,l)
         local h, res, i, ord;
             Info(InfoCTUnger, 3, "PowMap ord ", GR.orders[l], ", class ", l);
-Error("todo");
+#Error("todo");
             if GR.orders[l]=1 then
               GR.powermaps[l]:=[l];
               return;
@@ -396,6 +396,8 @@ Error("todo");
             if GR.Elementary.isCyclic then
                 # some elementary groups contained in the cyclic group
                 for p in GR.CentralizerPrimes[i] do
+                    #Assert(0, GR.n/GR.ccsizes[i] = GR.orders[i]);
+                    #Assert(0, GR.n/GR.ccsizes[GR.IndexCyc] = GR.orders[GR.IndexCyc]);
                     if PValuation(GR.n/GR.ccsizes[i],p)=PValuation(GR.orders[GR.IndexCyc],p) then
                         RemoveSet(GR.CentralizerPrimes[i],p);
                         GR.NumberOfPrimes:=GR.NumberOfPrimes-1;


### PR DESCRIPTION
Contributes towards #5. On my M1 MacBook pro, the example there takes 52 seconds in a fresh GAP session with `master` of this package; with this PR it takes 33 seconds.

This is a draft for multiple reasons. It has not yet been tested thoroughly, it is not sufficiently documented, it could be more general, and finally it may be possible to replace some or all of it with calls to GAP library functions (@ThomasBreuer may know).

Currently this PR consists of quick hack that speeds up computing the powermap for elements with prime order. In the example above the first element being dealt with is one of prime order 307. Without this code, `FindClass` is called on elements of order 307 about 305 times. But there are "only" 102 classes of order 307. The new code exploits that the unit group $U$ of $\mathbb{Z}/307\mathbb{Z}$ acts on these classes, and $U$ is itself cyclic of order 306. We end up calling `FindClass` only 102 times before a cycle in the action of $U$ is detected. At that point the powermap can be completed super cheaply.

A second win comes from the observation that before we reach the original class again, there are no loops, and thus `FindClass` need not consider classes we used before.

With this PR, the places where we are inside LLL or post-processing LLL suddenly stand out much more (it might be useful to add in some code which computes an aggregate of how much time is spent in `FindClass` vs. `LLL` vs. other code path. Or we use the `profiling` package...).


To adapt this to the non-prime case, a natural next step would be to deal with elements $g$ whose order is a prime power $p^k$. There basically, for $i=0,\dots,k-1$ one can apply a similar trick by considering the orbit of $(\mathbb{Z}/p^{k-i}\mathbb{Z})^*$ on powers of $g^{p^i}$. And then finally similarly for arbitrary moduli.

But it doesn't make sense to work on that if @ThomasBreuer tells me it is all already there somewhere ;-)